### PR TITLE
Read API key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,19 @@ Logback
 Appender parameters:
 
 * url: The Rollbar API url. Default: https://api.rollbar.com/api/1/item/
-* apiKey: The rollbar API key. Mandatory.
+* apiKey: The rollbar API key. The API key is mandatory and has to be set either here or
+  [via an environment variable](#providing-the-api-key-externally).
 * environment: Environment. i.e. production, test, development. Mandatory.
+
+
+Providing the API key externally
+---------------------------------------
+
+You can choose to set the API key by using an environment variable. This way your API key stays out of your code and
+your source control repository.
+
+Create the environment variable `ROLLBAR_LOGBACK_API_KEY` and set its value to your API key. This value will
+override the value set in `logback.xml` (if set).
 
 
 Custom MDC parameters

--- a/src/main/java/com/tapstream/rollbar/RollbarAppender.java
+++ b/src/main/java/com/tapstream/rollbar/RollbarAppender.java
@@ -13,7 +13,9 @@ import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 
 public class RollbarAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{    
-    
+
+    private static final String ENV_VAR_APIKEY = "ROLLBAR_LOGBACK_API_KEY";
+
     private NotifyBuilder payloadBuilder;
     
     private URL url;
@@ -62,7 +64,16 @@ public class RollbarAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
     @Override
     public void start() {
         boolean error = false;
-        
+
+        try {
+            String environmentApiKey = System.getenv(ENV_VAR_APIKEY);
+            if(environmentApiKey != null){
+                this.apiKey = environmentApiKey;
+            }
+        } catch(SecurityException e){
+            addWarn("Access to environment variables was denied. ("+e.getMessage()+")");
+        }
+
         if (this.url == null) {
             addError("No url set for the appender named [" + getName() + "].");
             error = true;


### PR DESCRIPTION
This commit enables users to specify their API key in an environment variable. The value set in `logback.xml` is used as fallback.

This allows users to:
- **change the API key**, depending on the computer/server the application is deployed on (e.g. different keys for testing and production)
- **keep the key private** by not including it in source control
